### PR TITLE
nginx設定から不必要なlocationブロックを削除。Nuxt3のエラー解消

### DIFF
--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -21,10 +21,6 @@ server {
         proxy_set_header Host $host;
         proxy_cache_bypass $http_upgrade;
     }
-
-    location ~ /\.(?!well-known).* {
-        deny all;
-    }
 }
 
 server {


### PR DESCRIPTION
画面ロード時に読み込まれる https://front.local/_nuxt/@id/virtual:nuxt:%2Fapp%2F.nuxt%2Fcss.mjs などのファイルがnginx側で403を返してしまいエラーになっていた。
全てのパスをnuxtに返すように修正。